### PR TITLE
Use dynamic links instead of deep links

### DIFF
--- a/kamba-woocommerce-plugin/lib/KambaCheckout.php
+++ b/kamba-woocommerce-plugin/lib/KambaCheckout.php
@@ -63,7 +63,7 @@ Class KambaCheckout {
 		$total_amount = $resp['total_amount'];
 		$timestamp = strtotime($resp['expires_at']);
 		$expiration_date = date('d/m/Y H:i:s', $timestamp);
-		$checkout_mobile_link = "https://checkout.usekamba.com/v1/pay?mID=".$resp['id']."&chID=".$resp['id'];
+		$checkout_mobile_link = "https://usekamba.page.link/?link=https://www.usekamba.com/&apn=com.usekamba.kamba.kamba&ibi=com.usekamba.kamba&mID=".$resp['id']."&chID=".$resp['id'];
 		if ($this->test_mode) {
 		    $checkout_url = "https://sandbox.usekamba.com/v1/pay?mID=".$resp['merchant']['id']."&chID=".$resp['id'];
 		} else {
@@ -71,9 +71,7 @@ Class KambaCheckout {
 		}
 		phpAlert("Checkout URL $checkout_url");
 		setCheckout($checkout_url, $checkout_mobile_link, $business_name, $total_amount, $expiration_date, $notes);
-		
 		$err = curl_error($curl);
-
 		curl_close($curl);
 
 		if ($err) {


### PR DESCRIPTION
Esta PR adiciona suporte para o seguintes fluxos ou usecases:

Caso 1: O usuário clica no botão pagar com kamba no checkout js mas não tem o app instalado no seu device.  
Com dynamic links o usuário será redirecionado para o 1. Google Play ou 2. App Store para instalar o aplicativo.

Caso 2: Caso o aplicativo kamba já estiver instalado o app irá reconhecer o link e abrir a tela certa e extrair as informações do checkout (chId, mId), fazer uma chamada ao API e apresentar o checkout na tela de pagamentos.